### PR TITLE
[Dist/Debian] Add postinst and prerm script for example models

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,11 @@
+#!/bin/bash
+pushd /usr/lib/nnstreamer/bin
+/usr/lib/nnstreamer/bin/get-model.sh image-classification-tflite
+/usr/lib/nnstreamer/bin/get-model.sh image-classification-caffe2
+/usr/lib/nnstreamer/bin/get-model.sh object-detection-tf
+/usr/lib/nnstreamer/bin/get-model.sh object-detection-tflite
+/usr/lib/nnstreamer/bin/get-model.sh speech-command
+/usr/lib/nnstreamer/bin/get-model.sh image-segmentation-tflite
+/usr/lib/nnstreamer/bin/get-model.sh text-classification-tflite
+/usr/lib/nnstreamer/bin/get-model.sh pose-estimation-tflite
+popd

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,11 @@
+#!/bin/bash
+pushd /usr/lib/nnstreamer/bin
+rm -rf caffe2_model
+rm -rf speech_model
+rm -rf tflite_img_segment_model
+rm -rf tflite_model
+rm -rf tflite_model_img
+rm -rf tflite_pose_estimation
+rm -rf tflite_text_classification
+rm -rf tf_model
+popd


### PR DESCRIPTION
### Problem
After install `nnstreamer-example` debian package, users should manually install model
files using get-model.sh command. Moreover, some examples does not show
detailed error message and it makes users embarrassed as below.

```bash
$ python3 /usr/lib/nnstreamer/bin/nnstreamer_example_image_classification_tflite.py
ERROR:root:cannot find tflite model [/usr/lib/nnstreamer/bin/tflite_model_img/mobilenet_v1_1.0_224_quant.tflite]
Traceback (most recent call last):
  File "/usr/lib/nnstreamer/bin/nnstreamer_example_image_classification_tflite.py", line 239, in <module>
    example = NNStreamerExample(sys.argv[1:])
  File "/usr/lib/nnstreamer/bin/nnstreamer_example_image_classification_tflite.py", line 57, in __init__
    raise Exception
Exception
```

### Alternative solution
This patch automatically downloads all required models when installing debian
package so users can execute all examples without any errors.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped


