### PR TITLE
[Tizen.native] Init if all privileges are allowed  @open sesame 06/22 20:51

### DIFF
--- a/Tizen.native/ObjectDetection/src/main.c
+++ b/Tizen.native/ObjectDetection/src/main.c
@@ -187,7 +187,10 @@ void app_check_and_request_permissions()
       }
     }
 
-    if (allowed_count != privileges_count) {
+    if (allowed_count == privileges_count) {
+      init_pipeline();
+      view_create(NULL);
+    } else {
       dlog_print(DLOG_DEBUG, LOG_TAG, "PRIVILEGE CHECK IS REQUESTED");
       ret = ppm_request_permissions(askable_privileges,
           askable_privileges_count, app_request_multiple_response_cb, NULL);


### PR DESCRIPTION
[Problem] If all privileges are allowed before, pipeline and view are
not created.
[Solution] init_pipeline and view_create if allowed_count ==
privileges_count
