### PR TITLE
    [Tizen/IoT] Add nnfw as a option for text classification

### DIFF
--- a/Tizen.platform/Tizen_IoT_text_classification_NonGUI/res/MANIFEST
+++ b/Tizen.platform/Tizen_IoT_text_classification_NonGUI/res/MANIFEST
@@ -1,0 +1,7 @@
+{
+  "major-version" : "1",
+  "minor-version" : "0",
+  "patch-version" : "0",
+  "models"      : [ "text_classification.tflite" ],
+  "model-types" : [ "tflite" ]
+}

--- a/Tizen.platform/Tizen_IoT_text_classification_NonGUI/res/meson.build
+++ b/Tizen.platform/Tizen_IoT_text_classification_NonGUI/res/meson.build
@@ -2,3 +2,8 @@ res_install_dir =  join_paths(examples_install_dir, 'res')
 install_data(['labels.txt', 'vocab.txt', 'text_classification.tflite'],
   install_dir: res_install_dir
 )
+
+meta_install_dir =  join_paths(res_install_dir, 'metadata')
+install_data(['MANIFEST'],
+  install_dir: meta_install_dir
+)

--- a/Tizen.platform/Tizen_IoT_text_classification_NonGUI/src/nnstreamer_tizen_iot_text_classification.c
+++ b/Tizen.platform/Tizen_IoT_text_classification_NonGUI/src/nnstreamer_tizen_iot_text_classification.c
@@ -178,6 +178,9 @@ load_data (app_data_s * app)
     g_assert (app->words);
 
     for (i = 0; i < dics_len; i++) {
+      if (dics[i] == NULL || dics[i][0] == '\0')
+        continue;
+
       /* get word and index */
       gchar **word = g_strsplit (dics[i], " ", 2);
 
@@ -399,7 +402,7 @@ int main(int argc, char *argv[]){
   gst_bus_remove_signal_watch (app->bus);
   gst_object_unref (app->bus);
   gst_object_unref (app->pipeline);
-  g_free (host)
+  g_free (host);
   g_free (app->model_file);
   g_strfreev (app->labels);
   if (app->words != NULL)


### PR DESCRIPTION
Add nnfw as an option for text classification on Tizen IoT
    
Notes: text classification requires nnfw version 1.6.0 or more.
           Currently, Tizen is providing nnfw 1.4.0, but it will be upgraded to 1.7.0 next week.
    
Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>
