### PR TITLE
[Bash/Example/Segmentation] Improve visuals and performance

### DIFF
--- a/bash_script/example_image_segmentation_tensorflow_lite/gst-launch-image-segmentation-tflite.sh
+++ b/bash_script/example_image_segmentation_tensorflow_lite/gst-launch-image-segmentation-tflite.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 gst-launch-1.0 -v \
-    videomixer name=mix sink_0::alpha=0.7 sink_1::alpha=0.6 ! videoconvert ! autovideosink \
+    videomixer name=mix sink_0::alpha=1.0 sink_1::alpha=0.6 ! aspectratiocrop aspect-ratio=16/9 ! videoconvert ! autovideosink sync=false \
     v4l2src ! decodebin ! videoconvert ! videoscale ! \
     video/x-raw,format=RGB,width=257,height=257 ! tee name=t \
     t. ! queue ! mix. \


### PR DESCRIPTION
**before**
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/7823583/91133022-50c35080-e6e8-11ea-8cd6-6dab286b1c9f.gif)

**after**
![ezgif com-gif-maker](https://user-images.githubusercontent.com/7823583/91133325-66d11100-e6e8-11ea-9026-a97a70078b76.gif)


This patch makes the gst-launch image segmentation example looks more completed by adding three things:
* Remove the background checker pattern.
* Set sync=false for videosink to improve responsiveness of the result.
* Remove the letterbox. By the limitation of the model, the model tries to sement against the black letterbox too but it is hard to prevent it using available options in gst-launch-1.0. So it is simpler just to cut the result image.
One potential problem is that the original video isn't guaranteed to have a 16/9 ratio but it is a safe bet because most webcams have 16/9 ratio by default.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nnstreamer/nnstreamer-example/169)
<!-- Reviewable:end -->
