### PR TITLE
[Dist/debian] Exclude tensorflow for arm arch

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  nnstreamer, nnstreamer-dev,
  libcairo2-dev, libopencv-dev,
- tensorflow-lite-dev, tensorflow-dev [amd64 arm64], libprotobuf-dev [amd64 arm64]
+ tensorflow-lite-dev, tensorflow-dev [amd64], libprotobuf-dev [amd64 arm64]
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnsuite/nnstreamer-example
 


### PR DESCRIPTION
Since tensorflow for arm arch is not distributed, let's exclude it from debian packaging.

*NNStreamer-example package tested here: https://launchpad.net/~gichan-jang/+archive/ubuntu/ppa-build-test

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ *]Passed [ ]Failed [ ]Skipped