### PR TITLE
[Tizen/IoT] Modifiy spelling error

### DIFF
--- a/Tizen.platform/Tizen_IoT_text_classification_NonGUI/src/nnstreamer_tizen_iot_text_classification.c
+++ b/Tizen.platform/Tizen_IoT_text_classification_NonGUI/src/nnstreamer_tizen_iot_text_classification.c
@@ -306,7 +306,7 @@ int main(int argc, char *argv[]){
 
   if (argc < 4) {
     g_print ("Please the input values for 'tcp server/client', 'host ip address' and 'port' exactly. \n");
-    g_print ("e.g) $ ./nnstreamer_tien_iot_text_classification server tensorflow-lite 192.168.1.1 5001 (optional)nnfw\n");
+    g_print ("e.g) $ ./nnstreamer_tizen_iot_text_classification server tensorflow-lite 192.168.1.1 5001 (optional)nnfw\n");
     return 0;
   }
 


### PR DESCRIPTION
In this example, I found a spelling error.
"g_print ("e.g) $ ./nnstreamer_tien_iot_text_classification server tensorflow-lite 192.168.1.1 5001 (optional)nnfw\n");"
I modified "tien" to "tizen".

Signed-off-by: HyesuAhn <linim@naver.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped


