### PR TITLE
[Tizen/platform] fix typo in Tizen.platform ImageClassification

### DIFF
--- a/Tizen.platform/Tizen_IoT_ImageClassification/src/nnstreamer_tizen_iot_image_classification.c
+++ b/Tizen.platform/Tizen_IoT_ImageClassification/src/nnstreamer_tizen_iot_image_classification.c
@@ -394,7 +394,7 @@ int main(int argc, char *argv[]){
 
   if (argc < 5) {
     g_print ("Please the input values for 'tcp server/client', 'target', 'host ip address' and 'port' exactly. \n");
-    g_print ("e.g) $ ./nnstreamer_tien_iot_image_classification server \"coffee mug\" 192.168.1.1 5001 \n");
+    g_print ("e.g) $ ./nnstreamer_tizen_iot_image_classification server \"coffee mug\" 192.168.1.1 5001 \n");
     return 0;
   }
 


### PR DESCRIPTION
Fix typo in Tizen.platform ImageClassification example.
"nnstreamer_tien_iot_image_classification" => "nnstreamer_tizen_iot_image_classification"

Signed-off-by: JeonChangMin <imsameperson@gmail.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped