### PR TITLE
[Tizen/Native]change license to LGPL-2.1

### DIFF
--- a/Tizen.native/SingleSample/inc/nnstreamer-sample-single.h
+++ b/Tizen.native/SingleSample/inc/nnstreamer-sample-single.h
@@ -3,8 +3,8 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; 
+ * version 2.1 of the License.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/Tizen.native/SingleSample/src/nnstreamer-sample-single.c
+++ b/Tizen.native/SingleSample/src/nnstreamer-sample-single.c
@@ -3,8 +3,8 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; 
+ * version 2.1 of the License.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
https://github.com/nnstreamer/nnstreamer/issues/2588
[Finding 8](https://lfscanning.org/reports/lfai/nnstreamer-2020-06-02-db85d4bf-ad70-4abf-80a6-d52dd1f6f3f1.html)

changed license to LGPL-2.1
nnstreamer-example/Tizen.native/SingleSample/inc/nnstreamer-sample-single.h
nnstreamer-example/Tizen.native/SingleSample/src/nnstreamer-sample-single.c

Signed-off-by: HyesuAhn <linim@naver.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
