### PR TITLE
[Android] remove unnecessary method

### DIFF
--- a/android/example_app/api-sample/src/main/java/org/nnsuite/nnstreamer/sample/MainActivity.java
+++ b/android/example_app/api-sample/src/main/java/org/nnsuite/nnstreamer/sample/MainActivity.java
@@ -167,7 +167,6 @@ public class MainActivity extends Activity {
                 } else if (option == 5) {
                     Log.d(TAG, "==== Run pipeline example with custom filter ====");
                     runPipeCustomFilter();
-                    runSingleNNFW();
                 } else if (option == 6) {
                     Log.d(TAG, "==== Run pipeline example with NNFW model ====");
                     runPipeNNFW();


### PR DESCRIPTION
Fix Android API samples, remove invalid method call while running the samples in timer.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
