### PR TITLE
[README] Fix quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,12 @@ We provide example nnstreamer applications:
 $ sudo add-apt-repository ppa:nnstreamer/ppa
 $ sudo apt-get update
 $ sudo apt-get install nnstreamer
-```
-
-* Download nnstreamer example :
-```
-$ sudo add-apt-repository ppa:nnstreamer-example/ppa
-$ sudo apt-get update
 $ sudo apt-get install nnstreamer-example
 $ cd /usr/lib/nnstreamer/bin # binary install directory
 ```
 
+ *note: `nnstreamer-example` ppa was integrated into `nnstreamer` ppa.
+ 
 As of 2018/10/13, we support 16.04 and 18.04
 
 If you want to build nnstreamer example yourself, please refer to the link : [[Build example](https://github.com/nnstreamer/nnstreamer/wiki/usage-examples-screenshots#build-examples-ubuntu-1604)]


### PR DESCRIPTION
Since `nnstreamer-example` package moved to nnstreamer ppa.
Fix a quick start guide.

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped