### PR TITLE
[Android] native window handle

### DIFF
--- a/android/example_app/nnstreamer-media-ssd/jni/nnstreamer-jni.c
+++ b/android/example_app/nnstreamer-media-ssd/jni/nnstreamer-jni.c
@@ -611,8 +611,8 @@ gst_native_surface_init (JNIEnv * env, jobject thiz, jobject surface)
     if (data->native_window == new_native_window) {
       nns_logd ("New native window is the same as the previous one %p",
           data->native_window);
+      ANativeWindow_release (new_native_window);
       if (data->video_sink) {
-        gst_video_overlay_expose (GST_VIDEO_OVERLAY (data->video_sink));
         gst_video_overlay_expose (GST_VIDEO_OVERLAY (data->video_sink));
       }
       return;

--- a/android/example_app/nnstreamer-multi/jni/nnstreamer-jni.c
+++ b/android/example_app/nnstreamer-multi/jni/nnstreamer-jni.c
@@ -609,8 +609,8 @@ gst_native_surface_init (JNIEnv * env, jobject thiz, jobject surface)
     if (data->native_window == new_native_window) {
       nns_logd ("New native window is the same as the previous one %p",
           data->native_window);
+      ANativeWindow_release (new_native_window);
       if (data->video_sink) {
-        gst_video_overlay_expose (GST_VIDEO_OVERLAY (data->video_sink));
         gst_video_overlay_expose (GST_VIDEO_OVERLAY (data->video_sink));
       }
       return;

--- a/android/example_app/nnstreamer-ssd-autocapture/jni/nnstreamer-jni.c
+++ b/android/example_app/nnstreamer-ssd-autocapture/jni/nnstreamer-jni.c
@@ -636,9 +636,9 @@ gst_native_surface_init(JNIEnv *env, jobject thiz, jobject surface)
     {
       nns_logd("New native window is the same as the previous one %p",
                data->native_window);
+      ANativeWindow_release (new_native_window);
       if (data->video_sink)
       {
-        gst_video_overlay_expose(GST_VIDEO_OVERLAY(data->video_sink));
         gst_video_overlay_expose(GST_VIDEO_OVERLAY(data->video_sink));
       }
       return;

--- a/android/example_app/nnstreamer-ssd/jni/nnstreamer-jni.c
+++ b/android/example_app/nnstreamer-ssd/jni/nnstreamer-jni.c
@@ -609,8 +609,8 @@ gst_native_surface_init (JNIEnv * env, jobject thiz, jobject surface)
     if (data->native_window == new_native_window) {
       nns_logd ("New native window is the same as the previous one %p",
           data->native_window);
+      ANativeWindow_release (new_native_window);
       if (data->video_sink) {
-        gst_video_overlay_expose (GST_VIDEO_OVERLAY (data->video_sink));
         gst_video_overlay_expose (GST_VIDEO_OVERLAY (data->video_sink));
       }
       return;

--- a/android/example_app/nnstreamer-ssd/res/layout/main.xml
+++ b/android/example_app/nnstreamer-ssd/res/layout/main.xml
@@ -28,9 +28,3 @@
         android:layout_centerInParent="true" />
 
 </RelativeLayout>
-
-
-
-
-
-

--- a/android/multi_device_shared_lib/jni/NNStreamerMultiDevice.c
+++ b/android/multi_device_shared_lib/jni/NNStreamerMultiDevice.c
@@ -566,8 +566,8 @@ append_description (gchar * old, gchar * str, const gchar * color)
 }
 
 /**
- * @brief set description 
- * 0: Default ( Camera ) 
+ * @brief set description
+ * 0: Default ( Camera )
  * 1: Face Detection
  * 2: Hand Detection
  * 3: Pose Estimation
@@ -904,8 +904,8 @@ gst_native_surface_init (JNIEnv * env, jobject thiz, jobject surface)
     if (data->native_window == new_native_window) {
       GST_DEBUG ("New native window is the same as the previous one %p",
           data->native_window);
+      ANativeWindow_release (new_native_window);
       if (data->video_sink) {
-        gst_video_overlay_expose (GST_VIDEO_OVERLAY (data->video_sink));
         gst_video_overlay_expose (GST_VIDEO_OVERLAY (data->video_sink));
       }
       return;


### PR DESCRIPTION
1. release native window handle when initializing same surface.
2. remove duplicated expose function.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
