### PR TITLE
[NET/wearable] Update Tizen SDK version and API level

### DIFF
--- a/Tizen.NET/OrientationDetection/OrientationDetection/OrientationDetection.Tizen.Wearable/OrientationDetection.Tizen.Wearable.csproj
+++ b/Tizen.NET/OrientationDetection/OrientationDetection/OrientationDetection.Tizen.Wearable/OrientationDetection.Tizen.Wearable.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.5">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen60</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -17,10 +17,8 @@
     <Folder Include="res\" />
   </ItemGroup>
 
-  
   <ItemGroup>
     <ProjectReference Include="..\OrientationDetection\OrientationDetection.csproj" />
   </ItemGroup>
-  
 
 </Project>

--- a/Tizen.NET/OrientationDetection/OrientationDetection/OrientationDetection.Tizen.Wearable/tizen-manifest.xml
+++ b/Tizen.NET/OrientationDetection/OrientationDetection/OrientationDetection.Tizen.Wearable/tizen-manifest.xml
@@ -1,16 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns="http://tizen.org/ns/packages" api-version="5.5" package="org.tizen.example.OrientationDetection.Tizen.Wearable" version="1.0.0">
-	<profile name="wearable" />
-	<ui-application appid="org.tizen.example.OrientationDetection.Tizen.Wearable"
-					exec="OrientationDetection.Tizen.Wearable.dll"
-					type="dotnet"
-					multiple="false"
-					taskmanage="true"
-					nodisplay="false"
-					launch_mode="single"
-					api-version="6">
-  <label>OrientationDetection.Tizen.Wearable</label>
-	<icon>OrientationDetection.Tizen.Wearable.png</icon>
+<manifest package="org.tizen.example.OrientationDetection.Tizen.Wearable" version="1.0.0" api-version="6" xmlns="http://tizen.org/ns/packages">
+    <profile name="wearable" />
+    <ui-application appid="org.tizen.example.OrientationDetection.Tizen.Wearable" exec="OrientationDetection.Tizen.Wearable.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet" launch_mode="single">
+        <label>OrientationDetection.Tizen.Wearable</label>
+        <icon>OrientationDetection.Tizen.Wearable.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true" />
-	</ui-application>
+        <splash-screens />
+    </ui-application>
+    <shortcut-list />
+    <dependencies />
+    <provides-appdefined-privileges />
 </manifest>

--- a/Tizen.NET/OrientationDetection/OrientationDetection/OrientationDetection/OrientationDetection.cs
+++ b/Tizen.NET/OrientationDetection/OrientationDetection/OrientationDetection/OrientationDetection.cs
@@ -141,7 +141,7 @@ namespace OrientationDetection
     {
       LabelUpdateLoop();
     }
-    
+
     /**
      * @brief Handle when app sleeps
      */

--- a/Tizen.NET/OrientationDetection/OrientationDetection/OrientationDetection/OrientationDetection.csproj
+++ b/Tizen.NET/OrientationDetection/OrientationDetection/OrientationDetection/OrientationDetection.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.5">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tizen.NET.API8" Version="8.0.0.15408" />
-    <PackageReference Include="Xamarin.Forms" Version="4.3.0.908675" />
+    <PackageReference Include="Tizen.NET" Version="8.0.0.15631" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
   </ItemGroup>
 
 </Project>

--- a/Tizen.native/OrientationDetection/.project
+++ b/Tizen.native/OrientationDetection/.project
@@ -25,7 +25,7 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1594778075602</id>
+			<id>1608796267302</id>
 			<name></name>
 			<type>26</type>
 			<matcher>
@@ -34,7 +34,7 @@
 			</matcher>
 		</filter>
 		<filter>
-			<id>1594778075606</id>
+			<id>1608796267305</id>
 			<name></name>
 			<type>6</type>
 			<matcher>

--- a/Tizen.native/OrientationDetection/.tproject
+++ b/Tizen.native/OrientationDetection/.tproject
@@ -2,7 +2,7 @@
 <tproject xmlns="http://www.tizen.org/tproject">
     <platforms>
         <platform>
-            <name>wearable-5.5</name>
+            <name>wearable-6.0</name>
         </platform>
     </platforms>
     <package>

--- a/Tizen.native/OrientationDetection/project_def.prop
+++ b/Tizen.native/OrientationDetection/project_def.prop
@@ -1,7 +1,7 @@
 APPNAME = orientationdetection
 
 type = app
-profile = wearable-5.5
+profile = wearable-6.0
 
 USER_SRCS = src/orientationdetection.c
 USER_DEFS =

--- a/Tizen.native/OrientationDetection/tizen-manifest.xml
+++ b/Tizen.native/OrientationDetection/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns="http://tizen.org/ns/packages" api-version="5.5" package="org.example.orientationdetection" version="1.0.0">
+<manifest xmlns="http://tizen.org/ns/packages" api-version="6.0" package="org.example.orientationdetection" version="1.0.0">
 	<profile name="wearable" />
 	<ui-application appid="org.example.orientationdetection" exec="orientationdetection" type="capp" multiple="false" taskmanage="true" nodisplay="false">
 		<icon>orientationdetection.png</icon>


### PR DESCRIPTION
For wearable sample app OrientationDetection

.NET APP
- Set Tizen .NET API level to 8 (tizen 6.0)
- Update Tizen sdk version

Native APP
- Set target profile to wearable 6.0

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
