### PR TITLE
alsa device should be configurable for speech_command example

### DIFF
--- a/native/example_pose_estimation_tflite/README.md
+++ b/native/example_pose_estimation_tflite/README.md
@@ -5,7 +5,7 @@ title: Pose Estimation
 ## Ubuntu Native NNStreamer Application Example - Pose Estimation (Single Person)
 ### Introduction
 This example passes camera video stream to a neural network using **tensor_filter**.
-The neural network predicts positions of 17 body parts of the person in input stream. The results are drawn by **cairooveray** GStreamer plugin.
+The neural network predicts positions of 17 body parts of the person in input stream. The results are drawn by **cairooverlay** GStreamer plugin.
 
 ### How to Run
 This example requires pose estimation tf lite model and key point label (for body parts).  

--- a/native/example_speech_command_tensorflow_lite/nnstreamer_example_speech_command_tflite.c
+++ b/native/example_speech_command_tensorflow_lite/nnstreamer_example_speech_command_tflite.c
@@ -376,8 +376,10 @@ timer_update_result_cb (gpointer user_data)
  * @brief Main function.
  */
 int
-main (int argc, char **argv)
+main (int argc, char *argv[])
 {
+
+  printf("\n\nUsage:\n./nnstreamer_example_speech_command [alsasrc_device]\n\n");
   /* check your device */
   const gchar alsa_device[] = "hw:2";
   const gchar tflite_model_path[] = "./speech_model";
@@ -414,7 +416,7 @@ main (int argc, char **argv)
       "tensor_transform mode=arithmetic option=typecast:float32,div:32767.0 ! "
       "tensor_filter framework=custom model=./libnnscustom_speech_command_tflite.so ! "
       "tensor_filter framework=tensorflow-lite model=%s ! tensor_sink name=tensor_sink",
-      alsa_device, g_app.tflite_info.model_path);
+      argc > 1 ? argv[1] : alsa_device, g_app.tflite_info.model_path);
 
   /**
    * tensor info (conv_actions_frozen.tflite)

--- a/native/example_speech_command_tensorflow_lite/nnstreamer_example_speech_command_tflite.c
+++ b/native/example_speech_command_tensorflow_lite/nnstreamer_example_speech_command_tflite.c
@@ -378,7 +378,6 @@ timer_update_result_cb (gpointer user_data)
 int
 main (int argc, char *argv[])
 {
-
   printf("\n\nUsage:\n./nnstreamer_example_speech_command [alsasrc_device]\n\n");
   /* check your device */
   const gchar alsa_device[] = "hw:2";


### PR DESCRIPTION
Signed-off-by: shortcipher3 <chris.jon.hall@gmail.com>


---
# `alsasrc` device should be configurable

Summarize changes in around 50 characters or less

In the speech command example the device used for recording audio is hard-coded (`alsasrc device="hw:2"`) this program should probably use the `"default"` device or at minimum allow the users to specify their device of choice in the cli.

The ppa `nnstreamer-example` repository contains pre-compiled examples, so it is unexpected for one of the examples to have a hardcoded audio device that is not available on most hardware.

**Changes proposed in this PR:**
- Allow `nnstreamer_example_speech_command_tflite` to take an argument, the audio device 

**How to evaluate:**
1. `./nnstreamer_example_speech_command_tflite default`

