### PR TITLE
[Example] Fix java api examples @open sesame 4/25 12:38

### DIFF
--- a/android/example_app/style-transfer-with-nnstreamer-java-api/src/main/java/org/nnsuite/nnstreamer/sample/MainActivity.java
+++ b/android/example_app/style-transfer-with-nnstreamer-java-api/src/main/java/org/nnsuite/nnstreamer/sample/MainActivity.java
@@ -173,9 +173,9 @@ public class MainActivity extends Activity {
 
         currentPipe = new Pipeline(getDesc());
         mCamera = Camera.open();
+
         resetView();
         resetCamera();
-        mCamera.setPreviewCallback(getNewPreviewCallback());
     }
 
     private void copyFilesToExternalDir()
@@ -255,6 +255,7 @@ public class MainActivity extends Activity {
                 try {
                     mCamera.stopPreview();
                     mCamera.setPreviewDisplay(holder);
+                    mCamera.setPreviewCallback(getNewPreviewCallback());
                     mCamera.startPreview();
                     Log.d(TAG, "Preview resumed.");
                 } catch (Exception e) {
@@ -284,7 +285,7 @@ public class MainActivity extends Activity {
             @Override
             public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
                 Log.d(TAG, "Styledview surface changed");
-                getCurrentPipe().setSurface("sinkstyled", holder);
+                getCurrentPipe().setSurface("sinkstyled", holder.getSurface());
             }
 
             @Override
@@ -328,7 +329,6 @@ public class MainActivity extends Activity {
                     getCurrentPipe().inputData("src1", input1);
 
                     getCurrentPipe().stop();
-
                 }
                 if(updateFrame > updateLimit)
                 {

--- a/android/example_app/style-transfer-with-nnstreamer-java-api/src/main/java/org/nnsuite/nnstreamer/sample/MainActivity.java
+++ b/android/example_app/style-transfer-with-nnstreamer-java-api/src/main/java/org/nnsuite/nnstreamer/sample/MainActivity.java
@@ -358,7 +358,7 @@ public class MainActivity extends Activity {
                 "videoconvert ! " +
                 "video/x-raw,format=RGB,width=640,height=480,framerate=(fraction)0/1 ! " +
                 "videoflip method=clockwise ! videocrop left=0 right=0 top=80 bottom=80 ! " +
-                "videoconvert ! videoscale ! video/x-raw,width=384,height=384 ! tensor_converter ! " +
+                "videoscale ! video/x-raw,width=384,height=384 ! tensor_converter ! " +
                 "other/tensor,dimension=(string)3:384:384:1,type=(string)uint8,framerate=(fraction)0/1 ! " +
                 "tensor_transform mode=arithmetic option=typecast:float32,add:0.0,div:255.0 ! mux.sink_0 "+
                 "appsrc name=src1 ! " +

--- a/android/example_app/use-camera-with-nnstreamer-java-api/src/main/java/org/nnsuite/nnstreamer/sample/MainActivity.java
+++ b/android/example_app/use-camera-with-nnstreamer-java-api/src/main/java/org/nnsuite/nnstreamer/sample/MainActivity.java
@@ -60,16 +60,6 @@ public class MainActivity extends Activity {
 
         mCamera.setParameters(parameters);
         mCamera.setDisplayOrientation(90);
-        mCamera.setPreviewCallback(new Camera.PreviewCallback() {
-            @Override
-            public void onPreviewFrame(byte[] data, Camera camera) {
-                TensorsData input = info.allocate();
-                ByteBuffer buffer = input.getTensorData(0);
-                buffer.put(Arrays.copyOf(data, data.length));
-                input.setTensorData(0, buffer);
-                pipe.inputData("srcx", input);
-            }
-        });
     }
 
     private void initView() {
@@ -87,6 +77,16 @@ public class MainActivity extends Activity {
                     mCamera.stopPreview();
 
                     mCamera.setPreviewDisplay(holder);
+                    mCamera.setPreviewCallback(new Camera.PreviewCallback() {
+                        @Override
+                        public void onPreviewFrame(byte[] data, Camera camera) {
+                            TensorsData input = info.allocate();
+                            ByteBuffer buffer = input.getTensorData(0);
+                            buffer.put(Arrays.copyOf(data, data.length));
+                            input.setTensorData(0, buffer);
+                            pipe.inputData("srcx", input);
+                        }
+                    });
                     mCamera.startPreview();
                     Log.d(TAG, "Preview resumed.");
                 } catch (Exception e) {
@@ -114,7 +114,7 @@ public class MainActivity extends Activity {
             @Override
             public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
                 Log.d(TAG, "Scaledview surface changed");
-                pipe.setSurface("sinkscaled", holder);
+                pipe.setSurface("sinkscaled", holder.getSurface());
             }
 
             @Override
@@ -132,7 +132,7 @@ public class MainActivity extends Activity {
             @Override
             public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
                 Log.d(TAG, "Flippedview surface changed");
-                pipe.setSurface("sinkflipped", holder);
+                pipe.setSurface("sinkflipped", holder.getSurface());
             }
 
             @Override


### PR DESCRIPTION
There are two major problems in example projects.

1. Registration of `setPreviewCallback` was not worked in my recent Android10 device. I fixed it to register callback immediately after setting the preview display.
2. Current gstreamer pipeline in `style-transfer-with-nnstreamer-java-api` causes `E/GStreamer+videoconvert: 0:00:01.553407343 0x7c60d44de0 ../gst/videoconvert/gstvideoconvert.c:618:gst_video_convert_set_info:<videoconvert1> input and output formats do not match` error in GStreamer 1.20.0. I don't know the exact reasons but after I removed `videoconvert` in the pipeline, it worked well.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
4. Run test: [ ]Passed [ ]Failed [* ]Skipped

