### PR TITLE
[debian] Make tensorflow1 optional.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends:
  gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  nnstreamer, nnstreamer-dev, nnstreamer-edge-dev,
  libcairo2-dev, libopencv-dev,
- tensorflow-lite-dev, tensorflow-dev [amd64], libprotobuf-dev [amd64 arm64]
+ tensorflow2-lite-dev | tensorflow-lite-dev, tensorflow-dev [amd64] | tensorflow2-dev [amd64] | gcc, libprotobuf-dev [amd64 arm64]
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nnstreamer-example
 


### PR DESCRIPTION
We are dropping tensorflow 1.x support.
Make it optional so that older releases can keep building with TF 1.x and newer releases can drop TF 1.x and use TF 2.x instead.

This is required for Ubuntu 22.04 support: https://github.com/nnstreamer/nnstreamer/issues/4088