### PR TITLE
[nnstreamer_training_offloading] Add wait-connection and connection-timeout

### DIFF
--- a/native/example_training_offloading/nnstreamer_example_training_offloading.c
+++ b/native/example_training_offloading/nnstreamer_example_training_offloading.c
@@ -182,7 +182,8 @@ main (int argc, char **argv)
     str_pipeline =
         g_strdup_printf
         ("datareposrc location=%s json=%s epochs=%d start-sample-index=%d stop-sample-index=%d ! "
-        "edgesink port=0 connect-type=HYBRID topic=tempTopic dest-host=%s dest-port=%d",
+        "edgesink port=0 connect-type=HYBRID topic=tempTopic dest-host=%s dest-port=%d "
+        "wait-connection=true connection-timeout=10000 ",
         filename, json, epochs, start_sample_index, stop_sample_index,
         dest_host, dest_port);
   } else if (!g_strcmp0 (stream_role, "receiver")) {


### PR DESCRIPTION
Add wait-connection and connection-timeout property to get all training data

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```

