### PR TITLE
[Debian] Remove tf dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,6 @@ Package: nnstreamer-example
 Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}, nnstreamer,
- nnstreamer-tensorflow-lite, nnstreamer-tensorflow [amd64]
+ nnstreamer-tensorflow2-lite
 Description: Examples of nnstreamer
  This package contains the examples of nnstreamer.


### PR DESCRIPTION
Remove tensorflow dependency from nns-example package.


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

