### PR TITLE
[Example] ml service API name is changed

### DIFF
--- a/Tizen.native/MNIST_inference_after_training_offloading/README.md
+++ b/Tizen.native/MNIST_inference_after_training_offloading/README.md
@@ -145,6 +145,19 @@ Example of inference of the number 9
 * Update Tizen package manager to the latest.
 * Prepare 2 RPI4 units.
 * RPI4 flashed with the latest tizen headed image.
+* Install mosquitto package on RPI4 to use MQTT, download rpm (mosquitto and mosquitto-client) from [this page](http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified/reference/repos/standard/packages/)(There are armv7l and aarch64 architectures for RPI4.)
+```
+  [host]
+  sdb push mosquitto-1.6.8-0.armv7l.rpm mosquitto-clients-1.6.8-0.armv7l.rpm
+  or
+  sdb push mosquitto-1.6.8-0.aarch64.rpm mosquitto-clients-1.6.8-0.aarch64.rpm
+  
+  [target]
+  rpm -Uvh *.rpm
+  cd /etc/mosquitto
+  cp mosquitto.conf.example mosquitto.conf
+  systemctl start mosquitto
+```
 * Connect PC and RPI4 for sender application.
 * Unzip data.zip in the res folder.
 * Launch Tizen Studio

--- a/Tizen.native/MNIST_inference_after_training_offloading/receiver/src/receiver.c
+++ b/Tizen.native/MNIST_inference_after_training_offloading/receiver/src/receiver.c
@@ -85,10 +85,10 @@ destroy_ml_service_handle (appdata_s * ad)
     ml_option_destroy (ad->service_option_h);
     ad->service_option_h = NULL;
   }
-  /** bug
-     if (ad->service_h)
+  if (ad->service_h) {
      ml_service_destroy (ad->service_h);
-   */
+     ad->service_h = NULL;
+  }
 }
 
 /**
@@ -411,14 +411,14 @@ start_model_sender (appdata_s * ad)
     return;
   }
 
-  ret = ml_option_set (ad->option_h, "node-type", "remote_sender", g_free);
+  ret = ml_option_set (ad->option_h, "node-type", "remote_sender", NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG,
         "Failed to set node-type(remote_sender)(%d)", ret);
     return;
   }
 
-  ret = ml_option_set (ad->option_h, "dest-host", BROKER_IP, g_free);
+  ret = ml_option_set (ad->option_h, "dest-host", BROKER_IP, NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set dest-host (%d)", ret);
     return;
@@ -430,32 +430,32 @@ start_model_sender (appdata_s * ad)
     return;
   }
 #ifdef USE_HYBRID
-  ret = ml_option_set (ad->option_h, "connect-type", "HYBRID", g_free);
+  ret = ml_option_set (ad->option_h, "connect-type", "HYBRID", NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set connect-type (%d)", ret);
     return;
   }
 
-  ret = ml_option_set (ad->option_h, "host", "192.168.0.4", g_free);
+  ret = ml_option_set (ad->option_h, "host", "192.168.0.4", NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set dest-host (%d)", ret);
     return;
   }
 #else
-  ret = ml_option_set (ad->option_h, "connect-type", "AITT", g_free);
+  ret = ml_option_set (ad->option_h, "connect-type", "AITT", NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set connect-type (%d)", ret);
     return;
   }
 #endif
 
-  ret = ml_option_set (ad->option_h, "topic", "model_offloading_topic", g_free);
+  ret = ml_option_set (ad->option_h, "topic", "model_offloading_topic", NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set topic (%d)", ret);
     return;
   }
 
-  ret = ml_remote_service_create (ad->option_h, &ad->service_h);
+  ret = ml_service_remote_create (ad->option_h, &ad->service_h);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to create ml remote service (%d)",
         ret);
@@ -469,7 +469,7 @@ start_model_sender (appdata_s * ad)
   }
 
   ret =
-      ml_option_set (ad->service_option_h, "service-type", "model_raw", g_free);
+      ml_option_set (ad->service_option_h, "service-type", "model_raw", NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set service-type (%d)", ret);
     return;
@@ -483,13 +483,13 @@ start_model_sender (appdata_s * ad)
     return;
   }
 
-  ret = ml_option_set (ad->service_option_h, "activate", "true", g_free);
+  ret = ml_option_set (ad->service_option_h, "activate", "true", NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set activate (%d)", ret);
     return;
   }
 
-  ret = ml_option_set (ad->service_option_h, "name", MODEL_NAME, g_free);
+  ret = ml_option_set (ad->service_option_h, "name", MODEL_NAME, NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set name (%d)", ret);
     return;
@@ -502,7 +502,7 @@ start_model_sender (appdata_s * ad)
 
   ret =
       ml_option_set (ad->service_option_h, "description", model_description,
-      g_free);
+      NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set description (%d)", ret);
     return;
@@ -521,7 +521,7 @@ start_model_sender (appdata_s * ad)
   g_usleep (1000000);
 
   ret =
-      ml_remote_service_register (ad->service_h, ad->service_option_h,
+      ml_service_remote_register (ad->service_h, ad->service_option_h,
       ad->contents, len);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed ml_remote_service_register (%d)",

--- a/Tizen.native/MNIST_inference_after_training_offloading/sender/src/sender.c
+++ b/Tizen.native/MNIST_inference_after_training_offloading/sender/src/sender.c
@@ -86,22 +86,18 @@ typedef struct appdata
 static void
 destroy_ml_service_handle (appdata_s * ad)
 {
-  /** bug
   if (ad->option_h) {
     ml_option_destroy (ad->option_h);
     ad->option_h = NULL;
   }
-  */
   if (ad->service_h) {
     ml_service_destroy (ad->service_h);
     ad->service_h = NULL;
   }
-
   if (ad->activated_model_info) {
     ml_information_destroy (ad->activated_model_info);
     ad->activated_model_info = NULL;
   }
-
 }
 
 /**
@@ -549,14 +545,14 @@ start_model_receiver (appdata_s * ad)
     return;
   }
 
-  ret = ml_option_set (ad->option_h, "node-type", "remote_receiver", g_free);
+  ret = ml_option_set (ad->option_h, "node-type", "remote_receiver", NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG,
         "Failed to set node-type(remote_receiver)(%d)", ret);
     return;
   }
 
-  ret = ml_option_set (ad->option_h, "dest-host", BROKER_IP, g_free);
+  ret = ml_option_set (ad->option_h, "dest-host", BROKER_IP, NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set dest-host (%d)", ret);
     return;
@@ -567,33 +563,48 @@ start_model_receiver (appdata_s * ad)
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set dest-port (%d)", ret);
     return;
   }
+
+  /** A path to save the received model file */
+  g_autofree gchar *shared_path = app_get_shared_data_path ();
+  dlog_print (DLOG_ERROR, LOG_TAG, "path (%s)", shared_path);
+
+  /** Currently, the path setting function cannot be used because
+    it is not applied to the Tizen platform binary. It will be updated ASAP. */
+#if 0
+  ret = ml_option_set (ad->option_h, "path", shared_path, NULL);
+  if (ML_ERROR_NONE != ret) {
+    dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set path (%d)", ret);
+    return;
+  }
+#endif
+
 #ifdef USE_HYBRID
-  ret = ml_option_set (ad->option_h, "connect-type", "HYBRID", g_free);
+  ret = ml_option_set (ad->option_h, "connect-type", "HYBRID", NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set connect-type (%d)", ret);
     return;
   }
 #if 0
-  ret = ml_option_set (ad->option_h, "host", "192.168.0.6", g_free);
+  ret = ml_option_set (ad->option_h, "host", "192.168.0.6", NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set dest-host (%d)", ret);
     return;
   }
 #endif
 #else
-  ret = ml_option_set (ad->option_h, "connect-type", "AITT", g_free);
+  ret = ml_option_set (ad->option_h, "connect-type", "AITT", NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set connect-type (%d)", ret);
     return;
   }
 #endif
-  ret = ml_option_set (ad->option_h, "topic", "model_offloading_topic", g_free);
+  ret = ml_option_set (ad->option_h, "topic", "model_offloading_topic", NULL);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to set topic (%d)", ret);
     return;
   }
 
-  ret = ml_remote_service_create (ad->option_h, &ad->service_h);
+  ret = ml_service_remote_create (ad->option_h, &ad->service_h);
   if (ML_ERROR_NONE != ret) {
     dlog_print (DLOG_ERROR, LOG_TAG, "Failed to create ml remote service (%d)",
         ret);


### PR DESCRIPTION
- Add setting and start MQTT to md
- API name is changed from ml_remote_service_* to ml_service_remote_*
- bugfix: remove double free, unnecessary free function registered in function ml_option_set

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [*]Skipped
2. Run test: [*]Passed [ ]Failed [* ]Skipped
