### PR TITLE
[ml-service] Use pipeline conf from rpk

### DIFF
--- a/Tizen.native/ml-service-example/sum_and_add_model_rpk_v1/res/global/sum_and_add/rpk_config.json
+++ b/Tizen.native/ml-service-example/sum_and_add_model_rpk_v1/res/global/sum_and_add/rpk_config.json
@@ -12,6 +12,11 @@
       "name" : "sum_and_add_resource_conf",
       "path" : "sum_and_add.single.conf",
       "description" : "Notes for this conf file"
+    },
+    {
+      "name" : "sum_and_add_resource_pipeline_conf",
+      "path" : "sum_and_add.pipeline.conf",
+      "description" : "Notes for this conf file"
     }
   ]
 }

--- a/Tizen.native/ml-service-example/sum_and_add_model_rpk_v1/res/global/sum_and_add/sum_and_add.pipeline.conf
+++ b/Tizen.native/ml-service-example/sum_and_add_model_rpk_v1/res/global/sum_and_add/sum_and_add.pipeline.conf
@@ -1,0 +1,37 @@
+{
+  "pipeline" : {
+    "description" : "
+        appsrc name=tsrc caps=other/tensors,num_tensors=1,format=(string)static,types=(string)float32,dimensions=(string)4:1,framerate=(fraction)0/1 ! 
+        queue leaky=2 max-size-buffers=2 ! 
+        tensor_filter framework=tensorflow-lite model=mlagent://model/sum_and_add_model custom=Delegate:XNNPACK,NumThreads:2 latency=1 ! 
+        tensor_sink name=tsink",
+    "input_node" : [
+      {
+        "name" : "tsrc",
+        "info" : [
+          {
+            "type" : "float32",
+            "dimension" : "4:1"
+          }
+        ]
+      }
+    ],
+    "output_node" : [
+      {
+        "name" : "tsink",
+        "info" : [
+          {
+          "type" : "float32",
+          "dimension" : "1"
+          }
+        ]
+      }
+    ]
+  },
+  "information" :
+  {
+    "description" : "[sum_and_add_one.tflite] sum all values and add 1.0",
+    "input_node_name" : "tsrc",
+    "output_node_name" : "tsink"
+  }
+}

--- a/Tizen.native/ml-service-example/sum_and_add_model_rpk_v2/res/global/sum_and_add/rpk_config.json
+++ b/Tizen.native/ml-service-example/sum_and_add_model_rpk_v2/res/global/sum_and_add/rpk_config.json
@@ -12,6 +12,11 @@
       "name" : "sum_and_add_resource_conf",
       "path" : "sum_and_add.single.conf",
       "description" : "Notes for this conf file"
+    },
+    {
+      "name" : "sum_and_add_resource_pipeline_conf",
+      "path" : "sum_and_add.pipeline.conf",
+      "description" : "Notes for this conf file"
     }
   ]
 }

--- a/Tizen.native/ml-service-example/sum_and_add_model_rpk_v2/res/global/sum_and_add/sum_and_add.pipeline.conf
+++ b/Tizen.native/ml-service-example/sum_and_add_model_rpk_v2/res/global/sum_and_add/sum_and_add.pipeline.conf
@@ -1,0 +1,37 @@
+{
+  "pipeline" : {
+    "description" : "
+        appsrc name=tsrc caps=other/tensors,num_tensors=1,format=(string)static,types=(string)float32,dimensions=(string)4:1,framerate=(fraction)0/1 ! 
+        queue leaky=2 max-size-buffers=2 ! 
+        tensor_filter framework=tensorflow-lite model=mlagent://model/sum_and_add_model custom=Delegate:XNNPACK,NumThreads:2 latency=1 ! 
+        tensor_sink name=tsink",
+    "input_node" : [
+      {
+        "name" : "tsrc",
+        "info" : [
+          {
+            "type" : "float32",
+            "dimension" : "4:1"
+          }
+        ]
+      }
+    ],
+    "output_node" : [
+      {
+        "name" : "tsink",
+        "info" : [
+          {
+          "type" : "float32",
+          "dimension" : "1"
+          }
+        ]
+      }
+    ]
+  },
+  "information" :
+  {
+    "description" : "[sum_and_add_two.tflite] sum all values and add 2.0",
+    "input_node_name" : "tsrc",
+    "output_node_name" : "tsink"
+  }
+}


### PR DESCRIPTION
- Let the `sum_and_add` app use pipeline conf from rpks

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
