### PR TITLE
[Tizen/web] Use only 3 digits after decimal point

### DIFF
--- a/Tizen.web/ImageClassificationOffloading/js/main.js
+++ b/Tizen.web/ImageClassificationOffloading/js/main.js
@@ -75,7 +75,7 @@ function sinkListenerCallback(sinkName, data) {
   label.innerText = labels[maxIdx];
 
   const time = document.getElementById("time_" + type);
-  time.innerText = type + " : " + (endTime - startTime) + " ms";
+  time.innerText = type + " : " + (endTime - startTime).toFixed(3) + " ms";
 }
 
 /**


### PR DESCRIPTION
This patch removes meaningless dicimal points.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
