### PR TITLE
[doc] Add `Geon Kim` and Team `nnstreamer` to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,4 @@
 # The lists of people and groups are for github.com
 
 # All members of nnstreamer-team are supposed to review each other
-*           @jaeyun-jung @myungjoo @jijoongmoon @again4you @leemgs @wooksong @helloahn @kparichay @dongju-chae @gichan-jang @anyj0527 @zhoonit
-
+* @nnstreamer/nnstreamer @jaeyun-jung @myungjoo @jijoongmoon @again4you @leemgs @wooksong @helloahn @kparichay @dongju-chae @gichan-jang @anyj0527 @zhoonit @14kgun


### PR DESCRIPTION
Add `Geon Kim(g67.kim@samsung.com)` and team `nnstreamer` to codeowners.

Only Modify ".github/CODEOWNERS"

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
